### PR TITLE
Further strengthen testcases for logic and & or

### DIFF
--- a/testcases/step4/and_logic_true.c
+++ b/testcases/step4/and_logic_true.c
@@ -1,0 +1,3 @@
+int main() {
+    return 1 && 2;
+}

--- a/testcases/step5/initialize_logic_and.c
+++ b/testcases/step5/initialize_logic_and.c
@@ -1,0 +1,5 @@
+int main() {
+    int a = 2;
+    int b = a && 1;
+    return a;
+}


### PR DESCRIPTION
Thanks for @Co1lin 's advice (#2), I reviewed my code of logical and & or, fixed the bug and created a testcase similar to his in step 4. 

Furthermore, I found that the `land` code on guidebook is **not true** (it is `snez t1,t1 ; snez t2,t2 ; and t1,t1,t2`), it **modifies the source registers**! However in step 4, we can't identify this mistake. To identify this, in step 5, I attach the logical and on a variable, and return it, which can cause error.

A possible implement for `land` is like this:

`snez d, s1; sub d, zero, d; and d, d, s2; snez d, d;`