### PR TITLE
Failcase for missing semi after a declaration

### DIFF
--- a/failcases/step5/missing_semi.c
+++ b/failcases/step5/missing_semi.c
@@ -1,0 +1,4 @@
+int main() {
+    int a = 500
+    return a;
+}

--- a/testcases/step4/and_true.c
+++ b/testcases/step4/and_true.c
@@ -1,3 +1,3 @@
 int main() {
-    return 1 && -1;
+    return 1 && -2;
 }

--- a/testcases/step4/or_true.c
+++ b/testcases/step4/or_true.c
@@ -1,3 +1,3 @@
 int main() {
-    return 1 || 0;
+    return 100 || 0;
 }


### PR DESCRIPTION
Besides #2 , at parser-stage, when students try to finish `# TODO: Complete the action if the next is a declaration.`, they may forget to match the semicolon after a declaration. However, cases from step 1 to 6 haven't covered this case, which allows the wrong implementation to pass.