### PR TITLE
Testcase for call expression involving arguments in volatile registers

### DIFF
--- a/testcases/step9/arg_swap.c
+++ b/testcases/step9/arg_swap.c
@@ -1,0 +1,11 @@
+int g(int a, int b) {
+    return a + b;
+}
+
+int f(int x, int y) {
+    return g(y, x);
+}
+
+int main() {
+    return f(2, 3);
+}


### PR DESCRIPTION
为 Step 9 增加一个测例 `arg_swap`:

```c
int g(int a, int b) {
    return a + b;
}

int f(int x, int y) {
    return g(y, x);
}

int main() {
    return f(2, 3);
}
```

这对应着 Step 9 实验指导中的两处：

1. > 比较理想的方案是直接将参数从一个寄存器复制到目标参数寄存器，但这可能带来一些边角情况。
2. > 思考：如果前面暂时不解除 volatile 寄存器的绑定，这里可能会有什么问题？ 你有更高效的解决方案吗？

如果处理参数接收时采用了将输入参数直接绑定到寄存器（而非实验指导中推荐的将输入参数先从寄存器中存放至栈上）的做法，并且处理函数调用时采用直接将参数从一个寄存器复制到目标参数寄存器的做法，却没有妥善处理实参所处寄存器也是参数寄存器的情况，没有将实参所处寄存器解绑定，可能会出现调用 `g` 时，对第一个参数的传参直接生成 `mv a0, a1`，导致输入参数 `x` 的值被覆盖，最终造成计算结果错误。
